### PR TITLE
Evitar warning ENV en Dockerfile durante build y añadido mensaje de lista vacía

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get update && \
     sed -i -e 's/# es_ES.UTF-8 UTF-8/es_ES.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales
 
-ENV LANG es_ES.UTF-8
-ENV LC_ALL es_ES.UTF-8
-ENV TZ Europe/Madrid
+ENV LANG=es_ES.UTF-8
+ENV LC_ALL=es_ES.UTF-8
+ENV TZ=Europe/Madrid
 
 WORKDIR /app
 

--- a/src/wallbot/telegram/handlers.py
+++ b/src/wallbot/telegram/handlers.py
@@ -85,3 +85,5 @@ class TelegramHandlers:
                 text += chat_search.cat_ids
         if len(text) > 0:
             self.bot.send_message(message.chat.id, (text,))
+        else:
+            self.bot.send_message(message.chat.id, ("Lista vacía",))


### PR DESCRIPTION
He cambiado en Dockerfile los datos de ENV para que mantengan el nuevo formato ENV key=value y evitar el warning que sale al generar la imagen.

Tambien he añadido una respuesta a al comando /list para que indique que la lista esta vacía.